### PR TITLE
fix: rm text align justify

### DIFF
--- a/src/components/Ppolicy.astro
+++ b/src/components/Ppolicy.astro
@@ -3,9 +3,7 @@
     margin-top: 40px;
     margin-bottom: 10px;
   }
-  p {
-    text-align: justify;
-  }
+
   ul {
     display: block;
     text-align: left;


### PR DESCRIPTION
Мне кажется тут спейсинг текста на мобильной версии по лучше будет
@semyonkhakhulin посмотри пж мб и в других местах `text-algn: justify` с тэга p имеет смысл убрать